### PR TITLE
Added Autobahn Test Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SimpleTest/AutobahnTestSuite"]
+	path = SimpleTest/AutobahnTestSuite
+	url = https://github.com/tavendo/AutobahnTestSuite.git

--- a/SimpleTest/SimpleTest.xcodeproj/project.pbxproj
+++ b/SimpleTest/SimpleTest.xcodeproj/project.pbxproj
@@ -14,6 +14,10 @@
 		6B22F5D61A9D94C80052A037 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6B22F5D51A9D94C80052A037 /* Images.xcassets */; };
 		6B22F5D91A9D94C80052A037 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6B22F5D71A9D94C80052A037 /* LaunchScreen.xib */; };
 		6B22F5F11A9D967D0052A037 /* JFRWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B22F5F01A9D967D0052A037 /* JFRWebSocket.m */; };
+		FC1A3CD91ADC751800F0BDBD /* TestWebSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = FC1A3CD81ADC751800F0BDBD /* TestWebSocket.m */; };
+		FC1A3CDD1ADCCF1700F0BDBD /* TestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = FC1A3CDC1ADCCF1700F0BDBD /* TestOperation.m */; };
+		FC1A3CE01ADCCF9200F0BDBD /* TestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = FC1A3CDF1ADCCF9200F0BDBD /* TestCase.m */; };
+		FC1A3CE61ADD6C8A00F0BDBD /* TestCaseTableViewcell.m in Sources */ = {isa = PBXBuildFile; fileRef = FC1A3CE51ADD6C8A00F0BDBD /* TestCaseTableViewcell.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,6 +33,14 @@
 		6B22F5D81A9D94C80052A037 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		6B22F5EF1A9D967D0052A037 /* JFRWebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JFRWebSocket.h; path = ../../JFRWebSocket.h; sourceTree = "<group>"; };
 		6B22F5F01A9D967D0052A037 /* JFRWebSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JFRWebSocket.m; path = ../../JFRWebSocket.m; sourceTree = "<group>"; };
+		FC1A3CD71ADC751800F0BDBD /* TestWebSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestWebSocket.h; sourceTree = "<group>"; };
+		FC1A3CD81ADC751800F0BDBD /* TestWebSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestWebSocket.m; sourceTree = "<group>"; };
+		FC1A3CDB1ADCCF1600F0BDBD /* TestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestOperation.h; sourceTree = "<group>"; };
+		FC1A3CDC1ADCCF1700F0BDBD /* TestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestOperation.m; sourceTree = "<group>"; };
+		FC1A3CDE1ADCCF9200F0BDBD /* TestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestCase.h; sourceTree = "<group>"; };
+		FC1A3CDF1ADCCF9200F0BDBD /* TestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestCase.m; sourceTree = "<group>"; };
+		FC1A3CE41ADD6C8A00F0BDBD /* TestCaseTableViewcell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestCaseTableViewcell.h; sourceTree = "<group>"; };
+		FC1A3CE51ADD6C8A00F0BDBD /* TestCaseTableViewcell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestCaseTableViewcell.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +79,14 @@
 				6B22F5CD1A9D94C80052A037 /* AppDelegate.m */,
 				6B22F5CF1A9D94C80052A037 /* ViewController.h */,
 				6B22F5D01A9D94C80052A037 /* ViewController.m */,
+				FC1A3CE41ADD6C8A00F0BDBD /* TestCaseTableViewcell.h */,
+				FC1A3CE51ADD6C8A00F0BDBD /* TestCaseTableViewcell.m */,
+				FC1A3CDE1ADCCF9200F0BDBD /* TestCase.h */,
+				FC1A3CDF1ADCCF9200F0BDBD /* TestCase.m */,
+				FC1A3CD71ADC751800F0BDBD /* TestWebSocket.h */,
+				FC1A3CD81ADC751800F0BDBD /* TestWebSocket.m */,
+				FC1A3CDB1ADCCF1600F0BDBD /* TestOperation.h */,
+				FC1A3CDC1ADCCF1700F0BDBD /* TestOperation.m */,
 				6B22F5D21A9D94C80052A037 /* Main.storyboard */,
 				6B22F5D51A9D94C80052A037 /* Images.xcassets */,
 				6B22F5D71A9D94C80052A037 /* LaunchScreen.xib */,
@@ -155,9 +175,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				6B22F5D11A9D94C80052A037 /* ViewController.m in Sources */,
+				FC1A3CE61ADD6C8A00F0BDBD /* TestCaseTableViewcell.m in Sources */,
+				FC1A3CD91ADC751800F0BDBD /* TestWebSocket.m in Sources */,
 				6B22F5CE1A9D94C80052A037 /* AppDelegate.m in Sources */,
 				6B22F5F11A9D967D0052A037 /* JFRWebSocket.m in Sources */,
 				6B22F5CB1A9D94C80052A037 /* main.m in Sources */,
+				FC1A3CDD1ADCCF1700F0BDBD /* TestOperation.m in Sources */,
+				FC1A3CE01ADCCF9200F0BDBD /* TestCase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -300,6 +324,7 @@
 				6B22F5EA1A9D94C80052A037 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SimpleTest/SimpleTest/Base.lproj/Main.storyboard
+++ b/SimpleTest/SimpleTest/Base.lproj/Main.storyboard
@@ -1,38 +1,59 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="eZc-AT-9PT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="eZc-AT-9PT">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
     </dependencies>
     <scenes>
-        <!--Test-->
-        <scene sceneID="tne-QT-ifu">
+        <!--View Controller-->
+        <scene sceneID="MBl-40-mAc">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
-                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                <tableViewController id="ZVi-Km-AHy" customClass="ViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="ahI-gi-NQ5">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                    </view>
-                    <navigationItem key="navigationItem" title="Test" id="KaS-9g-oq5">
-                        <barButtonItem key="leftBarButtonItem" title="Disconnect" id="xT2-qa-Ptx">
-                            <connections>
-                                <action selector="disconnect:" destination="BYZ-38-t0r" id="BxQ-ed-i5D"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" title="Write Text" id="D1q-Pi-n6c">
-                            <connections>
-                                <action selector="writeText:" destination="BYZ-38-t0r" id="RDM-Yk-tdK"/>
-                            </connections>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BasicCellIdentifier" textLabel="8Ya-ui-98x" detailTextLabel="7dH-Ce-Cgo" style="IBUITableViewCellStyleValue2" id="Yip-dO-3ej" customClass="TestCaseTableViewcell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Yip-dO-3ej" id="qji-rZ-kVI">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8Ya-ui-98x">
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <color key="textColor" red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7dH-Ce-Cgo">
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="ZVi-Km-AHy" id="Z7f-4L-BjZ"/>
+                            <outlet property="delegate" destination="ZVi-Km-AHy" id="wjs-f7-BIo"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="lgV-rz-yEu">
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="mZE-yq-3QA">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="IEQ-4y-H0c">
+                                <rect key="frame" x="-23" y="-15" width="133" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Run">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
                         </barButtonItem>
                     </navigationItem>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Gdq-sf-Jfg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1117" y="387"/>
+            <point key="canvasLocation" x="1077" y="1048"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="UFL-As-qhC">
@@ -45,7 +66,7 @@
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="Bjw-HD-avp"/>
+                        <segue destination="ZVi-Km-AHy" kind="relationship" relationship="rootViewController" id="viB-QF-mmX"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dY6-22-E1A" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/SimpleTest/SimpleTest/TestCase.h
+++ b/SimpleTest/SimpleTest/TestCase.h
@@ -1,0 +1,26 @@
+//
+//  TestCase.h
+//  SimpleTest
+//
+//  Created by Adam Kaplan on 4/14/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, TestCaseStatus) {
+    TestCaseStatusNotRun = 0,
+    TestCaseStatusRunning,
+    TestCaseStatusPassed,
+    TestCaseStatusFailed
+};
+
+@interface TestCase : NSObject
+
+@property (nonatomic) NSString *summary;
+@property (nonatomic) NSString *expectation;
+@property (nonatomic) NSString *identifier;
+@property (nonatomic) NSInteger number;
+@property (nonatomic) TestCaseStatus status;
+
+@end

--- a/SimpleTest/SimpleTest/TestCase.m
+++ b/SimpleTest/SimpleTest/TestCase.m
@@ -1,0 +1,13 @@
+//
+//  TestCase.m
+//  SimpleTest
+//
+//  Created by Adam Kaplan on 4/14/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+#import "TestCase.h"
+
+@implementation TestCase
+
+@end

--- a/SimpleTest/SimpleTest/TestCaseTableViewcell.h
+++ b/SimpleTest/SimpleTest/TestCaseTableViewcell.h
@@ -1,0 +1,17 @@
+//
+//  TestCaseTableViewcell.h
+//  SimpleTest
+//
+//  Created by Adam Kaplan on 4/14/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@class TestCase;
+
+@interface TestCaseTableViewcell : UITableViewCell
+
+@property (nonatomic) TestCase *testCase;
+
+@end

--- a/SimpleTest/SimpleTest/TestCaseTableViewcell.m
+++ b/SimpleTest/SimpleTest/TestCaseTableViewcell.m
@@ -1,0 +1,115 @@
+//
+//  TestCaseTableViewcell.m
+//  SimpleTest
+//
+//  Created by Adam Kaplan on 4/14/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+#import "TestCaseTableViewcell.h"
+#import "TestCase.h"
+
+@interface TestCaseTableViewcell ()
+@property (nonatomic) UILabel *statusLabel;
+@end
+
+@implementation TestCaseTableViewcell
+
+- (void)awakeFromNib {
+    // Initialization code
+    self.statusLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 60, 30)];
+    self.statusLabel.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize]];
+    self.statusLabel.minimumScaleFactor = 0.2;
+    self.statusLabel.textAlignment = NSTextAlignmentRight;
+    
+    self.detailTextLabel.text = @" ";
+}
+
+/*
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+*/
+
+- (void)prepareForReuse {
+    [super prepareForReuse];
+    self.testCase = nil;
+    self.textLabel.text = nil;
+    self.detailTextLabel.text = nil;
+    self.accessoryView = nil;
+}
+
+- (void)setTestCase:(TestCase *)testCase {
+    [self.testCase removeObserver:self forKeyPath:@"identifier"];
+    [self.testCase removeObserver:self forKeyPath:@"summary"];
+    [self.testCase removeObserver:self forKeyPath:@"status"];
+    
+    _testCase = testCase;
+
+    if (testCase) {
+        [testCase addObserver:self forKeyPath:@"identifier" options:NSKeyValueObservingOptionNew context:nil];
+        [testCase addObserver:self forKeyPath:@"summary" options:NSKeyValueObservingOptionNew context:nil];
+        [testCase addObserver:self forKeyPath:@"status" options:NSKeyValueObservingOptionNew context:nil];
+    
+        self.textLabel.text = _testCase.identifier ?: @" "; // For some reason blank strings break the cell updating
+        self.detailTextLabel.text = _testCase.summary ?: @" "; // For some reason blank strings break the cell updating
+        [self updateStatusLabel];
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        if ([keyPath isEqualToString:@"identifier"]) {
+            weakSelf.textLabel.text = change[NSKeyValueChangeNewKey];
+        
+        } else if ([keyPath isEqualToString:@"summary"]) {
+            weakSelf.detailTextLabel.text = change[NSKeyValueChangeNewKey];
+            
+        } else {
+            [weakSelf updateStatusLabel];
+        }
+    });
+}
+
+- (void)updateStatusLabel {
+    static UIActivityIndicatorView *spinnerView;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        spinnerView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+        [spinnerView startAnimating];
+    });
+    
+    NSString *text;
+    switch (self.testCase.status) {
+        case TestCaseStatusNotRun:
+            text = @"-";
+            break;
+            
+        case TestCaseStatusPassed:
+            text = @"✔︎";
+            break;
+            
+        case TestCaseStatusFailed:
+            text = @"❌";
+            break;
+            
+        case TestCaseStatusRunning:
+            self.accessoryView = spinnerView;
+            break;
+            
+        default:
+            text = @"?";
+            break;
+    }
+    
+    if (text) {
+        self.statusLabel.text = text;
+        self.accessoryView = self.statusLabel;
+    }
+}
+
+@end

--- a/SimpleTest/SimpleTest/TestOperation.h
+++ b/SimpleTest/SimpleTest/TestOperation.h
@@ -1,0 +1,21 @@
+//
+//  TestOperation.h
+//  SimpleTest
+//
+//  Created by Adam Kaplan on 4/14/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class TestCase, TestWebSocket;
+
+@interface TestOperation : NSOperation
+
+@property (nonatomic) TestWebSocket *socket;
+
+@property (nonatomic) TestCase *testCase;
+
+- (instancetype)initWithTestCase:(TestCase *)testCase command:(NSString *)command;
+
+@end

--- a/SimpleTest/SimpleTest/TestOperation.m
+++ b/SimpleTest/SimpleTest/TestOperation.m
@@ -1,0 +1,107 @@
+//
+//  TestOperation.m
+//  SimpleTest
+//
+//  Created by Adam Kaplan on 4/14/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+#import "TestOperation.h"
+#import "JFRWebSocket.h"
+#import "TestWebSocket.h"
+#import "TestCase.h"
+
+static NSString *testAgent;
+
+@interface TestOperation () <JFRWebSocketDelegate>
+@property (nonatomic) BOOL isExecuting;
+@property (nonatomic) BOOL isFinished;
+@end
+
+@implementation TestOperation
+
++ (void)initialize {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        testAgent = [NSBundle bundleForClass:[self class]].bundleIdentifier;
+    });
+}
+
+- (instancetype)initWithTestCase:(TestCase *)testCase command:(NSString *)command {
+    if (self = [super init]) {
+        _testCase = testCase;
+        NSString *params = [NSString stringWithFormat:@"?case=%lu&agent=%@&", testCase.number, testAgent];
+        _socket = [TestWebSocket testSocketForCommand:command parameters:params];
+        _socket.delegate = self;
+    }
+    return self;
+}
+
+- (BOOL)isConcurrent {
+    return YES;
+}
+
+- (void)main {
+    self.isExecuting = YES;
+    self.testCase.status = TestCaseStatusRunning;
+    [self.socket connect];
+}
+
+- (void)setExecuting:(BOOL)executing finished:(BOOL)finished {
+    [self willChangeValueForKey:@"isExecuting"];
+    [self willChangeValueForKey:@"isFinished"];
+    
+    self.isExecuting = executing;
+    self.isFinished = finished;
+    
+    [self didChangeValueForKey:@"isFinished"];
+    [self didChangeValueForKey:@"isExecuting"];
+
+    //self.socket.delegate = nil; // breaks because we get disconnect before connect (???)
+}
+
+- (void)dealloc {
+    self.socket.delegate = nil;
+}
+
+#pragma mark -
+
+- (void)websocketDidConnect:(JFRWebSocket*)socket {
+    NSLog(@"[connected]");
+}
+
+- (void)websocketDidDisconnect:(JFRWebSocket *)socket error:(NSError *)error {
+    NSLog(@"[disconnected: %@]", [error localizedDescription]);
+    self.socket.lastError = error;
+    //@throw error;
+    //[self performSelector:@selector(done) withObject:nil afterDelay:1.5];
+    [self done];
+}
+
+- (void)websocket:(JFRWebSocket *)socket didReceiveMessage:(NSString *)string {
+    self.socket.receivedText = string;
+    [self.socket writeString:string];
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(done) object:nil];
+    [self performSelector:@selector(done) withObject:nil afterDelay:2.0];
+}
+
+- (void)websocket:(JFRWebSocket *)socket didReceiveData:(NSData *)data {
+    self.socket.receivedData = data;
+    [self.socket writeData:data];
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(done) object:nil];
+    [self performSelector:@selector(done) withObject:nil afterDelay:2.0];
+}
+
+- (void)websocketDidReceivePing:(JFRWebSocket *)socket {
+    self.socket.receivedPing = YES;
+    NSLog(@"* Ping!");
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(done) object:nil];
+    [self performSelector:@selector(done) withObject:nil afterDelay:2.0];
+}
+
+- (void)done {
+    [self setExecuting:NO finished:YES];
+}
+
+
+@end

--- a/SimpleTest/SimpleTest/TestWebSocket.h
+++ b/SimpleTest/SimpleTest/TestWebSocket.h
@@ -1,0 +1,22 @@
+//
+//  TestWebSocket.h
+//  SimpleTest
+//
+//  Created by Adam Kaplan on 4/13/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+#import "JFRWebSocket.h"
+
+@interface TestWebSocket : JFRWebSocket
+
+@property NSString *receivedText;
+@property NSData *receivedData;
+@property NSError *lastError;
+@property BOOL receivedPing;
+
++ (instancetype)testSocketForCommand:(NSString *)command;
+
++ (instancetype)testSocketForCommand:(NSString *)command parameters:(NSString *)params;
+
+@end

--- a/SimpleTest/SimpleTest/TestWebSocket.m
+++ b/SimpleTest/SimpleTest/TestWebSocket.m
@@ -1,0 +1,28 @@
+//
+//  TestWebSocket.m
+//  SimpleTest
+//
+//  Created by Adam Kaplan on 4/13/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+#import "TestWebSocket.h"
+
+@implementation TestWebSocket
+
++ (instancetype)testSocketForCommand:(NSString *)command {
+    return [self testSocketForCommand:command parameters:nil];
+}
+
++ (instancetype)testSocketForCommand:(NSString *)command parameters:(NSString *)params {
+    NSURL *baseUrl = [[NSURL URLWithString:@"ws://localhost:9001"] URLByAppendingPathComponent:command];
+    
+    if (params) {
+        baseUrl = [NSURL URLWithString:[[baseUrl absoluteString] stringByAppendingString:params]];
+    }
+    
+    TestWebSocket *socket = [[self alloc] initWithURL:baseUrl protocols:@[]];
+    return socket;
+}
+
+@end

--- a/SimpleTest/SimpleTest/ViewController.h
+++ b/SimpleTest/SimpleTest/ViewController.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ViewController : UIViewController
+@interface ViewController : UITableViewController
 
 
 @end

--- a/SimpleTest/SimpleTest/ViewController.m
+++ b/SimpleTest/SimpleTest/ViewController.m
@@ -8,49 +8,144 @@
 
 #import "ViewController.h"
 #import "JFRWebSocket.h"
+#import "TestWebSocket.h"
+#import "TestCase.h"
+#import "TestCaseTableViewcell.h"
+#import "TestOperation.h"
 
-@interface ViewController ()<JFRWebSocketDelegate>
-
-@property(nonatomic, strong)JFRWebSocket *socket;
-
+@interface ViewController ()
+@property (nonatomic) NSOperationQueue *queue;
+@property (nonatomic) NSMutableArray *testCases;
+@property (nonatomic) UIAlertView *alertView;
 @end
 
 @implementation ViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.socket = [[JFRWebSocket alloc] initWithURL:[NSURL URLWithString:@"ws://localhost:8080"] protocols:@[@"chat",@"superchat"]];
-    self.socket.delegate = self;
-    [self.socket connect];
+
+    self.queue = [NSOperationQueue new];
+    self.queue.maxConcurrentOperationCount = 1;
 }
 
-// pragma mark: WebSocket Delegate methods.
-
--(void)websocketDidConnect:(JFRWebSocket*)socket {
-    NSLog(@"websocket is connected");
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    
+    if (self.testCases) {
+        return;  // only need to automatically run one time
+    }
+    
+    TestOperation *countOp = [[TestOperation alloc] initWithTestCase:nil command:@"getCaseCount"];
+    [self.queue addOperation:countOp];
+    [self.queue addOperationWithBlock:^{
+        NSInteger testCount = [countOp.socket.receivedText integerValue];
+        NSLog(@"Test Count: %lu", testCount);
+        
+        NSMutableArray *testCases = [[NSMutableArray alloc] init];
+        for (int i = 1; i < testCount+1; i++) {
+            TestCase *testCase = [TestCase new];
+            testCase.number = i;
+            [testCases addObject:testCase];
+        }
+        self.testCases = [testCases copy];
+        [self.tableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:NO];
+        
+        for (TestCase *testCase in self.testCases) {
+            [self getAutobahnTestInfo:testCase];
+            [self runAutobahnTest:testCase];
+            [self verifyAutobahnTest:testCase];
+        }
+    }];
 }
 
--(void)websocketDidDisconnect:(JFRWebSocket*)socket error:(NSError*)error {
-    NSLog(@"websocket is disconnected: %@", [error localizedDescription]);
-        [self.socket connect];
+#pragma mark - test control
+
+- (void)getAutobahnTestInfo:(TestCase *)test {
+    TestOperation *op = [[TestOperation alloc] initWithTestCase:test command:@"getCaseInfo"];
+    [self.queue addOperation:op];
+    [self.queue addOperationWithBlock:^{
+        NSString *jsonStr = op.socket.receivedText;
+        NSData *jsonData = [NSData dataWithBytesNoCopy:(void *)[jsonStr UTF8String]
+                                                length:[jsonStr length]
+                                          freeWhenDone:NO];
+        NSDictionary *info = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:nil];
+        test.identifier = info[@"id"];
+        test.summary = info[@"description"];
+        
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            self.navigationItem.title = [NSString stringWithFormat:@"%03lu of %03lu", test.number, self.testCases.count];
+        });
+        NSLog(@"About to run %@ – %@", test.identifier, test.summary);
+    }];
 }
 
--(void)websocket:(JFRWebSocket*)socket didReceiveMessage:(NSString*)string {
-    NSLog(@"Received text: %@", string);
+- (void)runAutobahnTest:(TestCase *)test {
+    //NSLog(@"Running test %@ - %@", test.identifier, test.summary);
+    TestOperation *op = [[TestOperation alloc] initWithTestCase:test command:@"runCase"];
+    [self.queue addOperation:op];
 }
 
--(void)websocket:(JFRWebSocket*)socket didReceiveData:(NSData*)data {
-    NSLog(@"Received data: %@", data);
+- (void)verifyAutobahnTest:(TestCase *)test {
+    TestOperation *op = [[TestOperation alloc] initWithTestCase:test command:@"getCaseStatus"];
+    [self.queue addOperation:op];
+    [self.queue addOperationWithBlock:^{
+        NSString *jsonStr = op.socket.receivedText;
+        NSData *jsonData = [NSData dataWithBytesNoCopy:(void *)[jsonStr UTF8String]
+                                                length:[jsonStr length]
+                                          freeWhenDone:NO];
+        NSDictionary *info = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:nil];
+        if ([info[@"behavior"] isEqualToString:@"OK"]) {
+            NSLog(@"VERIFED %@", test.identifier);
+            test.status = TestCaseStatusPassed;
+        } else {
+            NSLog(@"FAILED: %@ - %@", test.identifier, test.summary);
+            test.status = TestCaseStatusFailed;
+        }
+    }];
 }
 
-// pragma mark: target actions.
+#pragma mark - Table View Datasource and Delegate
 
-- (IBAction)writeText:(UIBarButtonItem *)sender {
-    [self.socket writeString:@"hello there!"];
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
 }
 
-- (IBAction)disconnect:(UIBarButtonItem *)sender {
-    [self.socket disconnect];
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.testCases.count;
 }
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    TestCaseTableViewcell *cell = [tableView dequeueReusableCellWithIdentifier:@"BasicCellIdentifier" forIndexPath:indexPath];
+    
+    cell.testCase = self.testCases[indexPath.row];
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (!self.alertView) {
+        self.alertView = [[UIAlertView alloc] initWithTitle:nil
+                                                    message:nil
+                                                   delegate:nil
+                                          cancelButtonTitle:@"Dismiss"
+                                          otherButtonTitles:nil];
+    }
+    
+    TestCase *testCase = self.testCases[indexPath.row];
+    self.alertView.title = testCase.identifier;
+    self.alertView.message = testCase.summary;
+    
+    [self.alertView dismissWithClickedButtonIndex:0 animated:NO];
+    [self.alertView show];
+}
+
+/*
+ #pragma mark - Navigation
+ 
+ // In a storyboard-based application, you will often want to do a little preparation before navigation
+ - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+ // Get the new view controller using [segue destinationViewController].
+ // Pass the selected object to the new view controller.
+ }
+ */
 
 @end


### PR DESCRIPTION
See image below. The setup is enough to run quick Autobahn tests, viewing the results directly in the simulator (checkmark or X for pass/fail).

Note that tests fail randomly because the current Jetfire GCD integration has a few serious bugs that cause messages to arrive out of order. I'll put the fix for that in another PR because it's not related to the tests themselves.

![image](https://cloud.githubusercontent.com/assets/727953/7142868/8caa6cbc-e2a9-11e4-8c42-f15f0ea226f6.png)

Future change should be to support tests on device (i.e. different URL) and generating the Autobahn results web page (not a big deal).