### PR TITLE
Change how the value of headerOriginName is being generated

### DIFF
--- a/JFRWebSocket.h
+++ b/JFRWebSocket.h
@@ -51,6 +51,7 @@
 @interface JFRWebSocket : NSObject
 
 @property(nonatomic,weak)id<JFRWebSocketDelegate>delegate;
+@property(nonatomic, readonly) NSURL *url;
 
 /**
  constructor to create a new websocket.
@@ -115,7 +116,7 @@
 /**
  Use for SSL pinning.
  */
-@property(nonatomic)JFRSecurity *security;
+@property(nonatomic, strong)JFRSecurity *security;
 
 /**
  Set your own custom queue.


### PR DESCRIPTION
Heya,

For some reason, the service I'm working with expects the value of headerOriginName to be in a similar format to the one produced by SocketRocket. After this change all worked well (Cheers!). This pull request also contains some other, less significant updates (from debug traces to cosmetics).

Anyway, Love this library!
Have a wonderful weekend,
Doron Adler

**Changes:**
* Have headerOriginName be "http(s)://host:port" or "http(s)://host" rather than url.absoluteString
* self.optProtocols will be ignored when it is both nil as well as an empty array
* If protocols.length is 0, there is no need to add an empty headerWSProtocolName header entry
* Use BOOL as return value instead of JFRInternalHTTPStatus
* Have responseStatusCode represent the actual HTTP status coder Instead of JFRInternalHTTPStatus's value
