### PR TITLE
Fixing not-calling onDisconnect diring disconnect

### DIFF
--- a/JFRWebSocket.m
+++ b/JFRWebSocket.m
@@ -715,6 +715,9 @@ static const size_t  JFRMaxFrameSize        = 32;
             if([weakSelf.delegate respondsToSelector:@selector(websocketDidDisconnect:error:)]) {
                 [weakSelf.delegate websocketDidDisconnect:weakSelf error:error];
             }
+            if(weakSelf.onDisconnect) {
+                weakSelf.onDisconnect(error);
+            }
         });
     }
 }


### PR DESCRIPTION
Right now there are two mechanisms for notifications: delegate and callback methods. There is a bug. Only delegate (websocketDidDisconnect:error:) is called after socket is disconnected. Callback method (onDisconnect) is not called.

I've added onDisconnect the same way all other callbacks are handled.