### PR TITLE
Add nullability annotations

### DIFF
--- a/JFRWebSocket.h
+++ b/JFRWebSocket.h
@@ -23,43 +23,43 @@
  The websocket connected to its host.
  @param socket is the current socket object.
  */
--(void)websocketDidConnect:(JFRWebSocket*)socket;
+-(void)websocketDidConnect:(nonnull JFRWebSocket*)socket;
 
 /**
  The websocket was disconnected from its host.
  @param socket is the current socket object.
- @param error is return an error occured to trigger the disconnect.
+ @param error  is return an error occured to trigger the disconnect.
  */
--(void)websocketDidDisconnect:(JFRWebSocket*)socket error:(NSError*)error;
+-(void)websocketDidDisconnect:(nonnull JFRWebSocket*)socket error:(nullable NSError*)error;
 
 /**
  The websocket got a text based message.
  @param socket is the current socket object.
  @param string is the text based data that has been returned.
  */
--(void)websocket:(JFRWebSocket*)socket didReceiveMessage:(NSString*)string;
+-(void)websocket:(nonnull JFRWebSocket*)socket didReceiveMessage:(nonnull NSString*)string;
 
 /**
  The websocket got a binary based message.
  @param socket is the current socket object.
- @param data is the binary based data that has been returned.
+ @param data   is the binary based data that has been returned.
  */
--(void)websocket:(JFRWebSocket*)socket didReceiveData:(NSData*)data;
+-(void)websocket:(nonnull JFRWebSocket*)socket didReceiveData:(nullable NSData*)data;
 
 @end
 
 @interface JFRWebSocket : NSObject
 
-@property(nonatomic,weak)id<JFRWebSocketDelegate>delegate;
-@property(nonatomic, readonly) NSURL *url;
+@property(nonatomic,weak, nullable)id<JFRWebSocketDelegate>delegate;
+@property(nonatomic, readonly, nonnull) NSURL *url;
 
 /**
  constructor to create a new websocket.
- @param: url is the host you want to connect to.
- @param: protocols are the websocket protocols you want to use (e.g. chat,superchat).
+ @param url       the host you want to connect to.
+ @param protocols the websocket protocols you want to use (e.g. chat,superchat).
  @return a newly initalized websocket.
  */
-- (instancetype)initWithURL:(NSURL *)url protocols:(NSArray*)protocols;
+- (nonnull instancetype)initWithURL:(nonnull NSURL *)url protocols:(nullable NSArray*)protocols;
 
 /**
  connect to the host.
@@ -73,28 +73,28 @@
 
 /**
  write binary based data to the socket.
- @param is the binary data to write.
+ @param data the binary data to write.
  */
-- (void)writeData:(NSData*)data;
+- (void)writeData:(nonnull NSData*)data;
 
 /**
  write text based data to the socket.
- @param is the string to write.
+ @param string the string to write.
  */
-- (void)writeString:(NSString*)string;
+- (void)writeString:(nonnull NSString*)string;
 
 /**
  write ping to the socket.
- @param is the binary data to write (if desired).
+ @param data the binary data to write (if desired).
  */
-- (void)writePing:(NSData*)data;
+- (void)writePing:(nonnull NSData*)data;
 
 /**
  Add a header to send along on the the HTTP connect.
- @param: value is the string to send
- @param: key is the HTTP key name to send
+ @param value the string to send
+ @param key   the HTTP key name to send
  */
-- (void)addHeader:(NSString*)value forKey:(NSString*)key;
+- (void)addHeader:(nonnull NSString*)value forKey:(nonnull NSString*)key;
 
 /**
  returns if the socket is conneted or not.
@@ -116,32 +116,32 @@
 /**
  Use for SSL pinning.
  */
-@property(nonatomic, strong)JFRSecurity *security;
+@property(nonatomic, strong, nullable)JFRSecurity *security;
 
 /**
  Set your own custom queue.
  Default setting is dispatch_get_main_queue.
  */
-@property(nonatomic, strong)dispatch_queue_t queue;
+@property(nonatomic, strong, nullable)dispatch_queue_t queue;
 
 /**
  Block property to use on connect.
  */
-@property(nonatomic, strong)void (^onConnect)(void);
+@property(nonatomic, strong, nullable)void (^onConnect)(void);
 
 /**
  Block property to use on disconnect.
  */
-@property(nonatomic, strong)void (^onDisconnect)(NSError*);
+@property(nonatomic, strong, nullable)void (^onDisconnect)(NSError*_Nullable);
 
 /**
  Block property to use on receiving data.
  */
-@property(nonatomic, strong)void (^onData)(NSData*);
+@property(nonatomic, strong, nullable)void (^onData)(NSData*_Nullable);
 
 /**
  Block property to use on receiving text.
  */
-@property(nonatomic, strong)void (^onText)(NSString*);
+@property(nonatomic, strong, nullable)void (^onText)(NSString*_Nullable);
 
 @end

--- a/JFRWebSocket.m
+++ b/JFRWebSocket.m
@@ -54,16 +54,16 @@ typedef NS_ENUM(NSUInteger, JFRInternalErrorCode) {
 
 @interface JFRWebSocket ()<NSStreamDelegate>
 
-@property(nonatomic, strong)NSURL *url;
-@property(nonatomic, strong)NSInputStream *inputStream;
-@property(nonatomic, strong)NSOutputStream *outputStream;
-@property(nonatomic, strong)NSOperationQueue *writeQueue;
+@property(nonatomic, strong, nonnull)NSURL *url;
+@property(nonatomic, strong, null_unspecified)NSInputStream *inputStream;
+@property(nonatomic, strong, null_unspecified)NSOutputStream *outputStream;
+@property(nonatomic, strong, null_unspecified)NSOperationQueue *writeQueue;
 @property(nonatomic, assign)BOOL isRunLoop;
-@property(nonatomic, strong)NSMutableArray *readStack;
-@property(nonatomic, strong)NSMutableArray *inputQueue;
-@property(nonatomic, strong)NSData *fragBuffer;
-@property(nonatomic, strong)NSMutableDictionary *headers;
-@property(nonatomic, strong)NSArray *optProtocols;
+@property(nonatomic, strong, nonnull)NSMutableArray *readStack;
+@property(nonatomic, strong, nonnull)NSMutableArray *inputQueue;
+@property(nonatomic, strong, nullable)NSData *fragBuffer;
+@property(nonatomic, strong, nullable)NSMutableDictionary *headers;
+@property(nonatomic, strong, nullable)NSArray *optProtocols;
 @property(nonatomic, assign)BOOL isCreated;
 @property(nonatomic, assign)BOOL didDisconnect;
 @property(nonatomic, assign)BOOL certValidated;
@@ -71,6 +71,7 @@ typedef NS_ENUM(NSUInteger, JFRInternalErrorCode) {
 @end
 
 //Constant Header Values.
+NS_ASSUME_NONNULL_BEGIN
 static NSString *const headerWSUpgradeName     = @"Upgrade";
 static NSString *const headerWSUpgradeValue    = @"websocket";
 static NSString *const headerWSHostName        = @"Host";
@@ -82,6 +83,7 @@ static NSString *const headerWSVersionValue    = @"13";
 static NSString *const headerWSKeyName         = @"Sec-WebSocket-Key";
 static NSString *const headerOriginName        = @"Origin";
 static NSString *const headerWSAcceptName      = @"Sec-WebSocket-Accept";
+NS_ASSUME_NONNULL_END
 
 //Class Constants
 static char CRLFBytes[] = {'\r', '\n', '\r', '\n'};


### PR DESCRIPTION
Also, additionally cleaned up some documentation warnings Xcode8 decided to start throwing around.

IMO having nullability annotations are quite nice if only to communicate expectations. 

The only real test I ran was compiling/running the included sample app to ensure no new warnings/errors were generated.

