### PR TITLE
Fix: error dictionary uses value for key

### DIFF
--- a/JFRWebSocket.m
+++ b/JFRWebSocket.m
@@ -776,7 +776,7 @@ static const size_t  JFRMaxFrameSize        = 32;
 - (NSError*)errorWithDetail:(NSString*)detail code:(NSInteger)code userInfo:(NSDictionary *)userInfo
 {
     NSMutableDictionary* details = [NSMutableDictionary dictionary];
-    details[detail] = NSLocalizedDescriptionKey;
+    details[NSLocalizedDescriptionKey] = detail;
     if (userInfo) {
         [details addEntriesFromDictionary:userInfo];
     }


### PR DESCRIPTION
When constructing the error dictionary, `NSLocalizedDescriptionKey` should be the key not the value. This appears to be a simple typo that results in all errors in Swift being "The operation cannot be completed.".