### PR TITLE
Add option to only validate the top the cert chain.

### DIFF
--- a/JFRSecurity.h
+++ b/JFRSecurity.h
@@ -72,6 +72,11 @@
 @property(nonatomic)BOOL validatedDN;
 
 /**
+ Should the entire root cert signing chain be validated? Default is YES
+ */
+@property(nonatomic)BOOL validateEntireChain;
+
+/**
  Validate if the cert is legit or not.
  :param:  trust is the trust to validate
  :param: domain to validate along with the trust (can be nil)

--- a/JFRSecurity.m
+++ b/JFRSecurity.m
@@ -84,6 +84,7 @@
 /////////////////////////////////////////////////////////////////////////////
 - (instancetype)initWithCerts:(NSArray<JFRSSLCert*>*)certs publicKeys:(BOOL)publicKeys {
     if(self = [super init]) {
+        self.validateEntireChain = YES;
         self.validatedDN = YES;
         self.usePublicKeys = publicKeys;
         if(self.usePublicKeys) {
@@ -150,6 +151,10 @@
         SecTrustResultType result = 0;
         SecTrustEvaluate(trust,&result);
         if(result == kSecTrustResultUnspecified || result == kSecTrustResultProceed) {
+
+            if (!self.validateEntireChain) {
+                return true;
+            }
             NSInteger trustedCount = 0;
             for(NSData *serverData in serverCerts) {
                 for(NSData *certData in self.certificates) {


### PR DESCRIPTION
Starscream has a validateEntireChain property. This adds that same functionality to Jetfire.